### PR TITLE
link: ValidateName, NormalizeURLString, ValidateURLString

### DIFF
--- a/link/github.go
+++ b/link/github.go
@@ -4,7 +4,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/keys-pub/keys/encoding"
 	"github.com/pkg/errors"
 )
 
@@ -13,41 +12,46 @@ type github struct{}
 // Github service.
 var Github = &github{}
 
-func (s *github) Name() string {
+func (s *github) ID() string {
 	return "github"
 }
 
-func (s *github) NormalizeName(name string) string {
-	return name
+func (s *github) NormalizeURLString(name string, urs string) (string, error) {
+	return basicURLString(strings.ToLower(urs))
 }
 
-func (s *github) ValidateURL(name string, u *url.URL) (*url.URL, error) {
+func (s *github) ValidateURLString(name string, urs string) (string, error) {
+	u, err := url.Parse(urs)
+	if err != nil {
+		return "", err
+	}
 	if u.Scheme != "https" {
-		return nil, errors.Errorf("invalid scheme for url %s", u)
+		return "", errors.Errorf("invalid scheme for url %s", u)
 	}
 	if u.Host != "gist.github.com" {
-		return nil, errors.Errorf("invalid host for url %s", u)
+		return "", errors.Errorf("invalid host for url %s", u)
 	}
 	path := u.Path
 	path = strings.TrimPrefix(path, "/")
 	paths := strings.Split(path, "/")
 	if len(paths) != 2 {
-		return nil, errors.Errorf("path invalid %s for url %s", paths, u)
+		return "", errors.Errorf("path invalid %s for url %s", paths, u)
 	}
 	if paths[0] != name {
-		return nil, errors.Errorf("path invalid (name mismatch) %s != %s", paths[0], name)
+		return "", errors.Errorf("path invalid (name mismatch) %s != %s", paths[0], name)
 	}
-	return u, nil
+	return u.String(), nil
+}
+
+func (s *github) NormalizeName(name string) string {
+	name = strings.ToLower(name)
+	return name
 }
 
 func (s *github) ValidateName(name string) error {
-	isASCII := encoding.IsASCII([]byte(name))
-	if !isASCII {
-		return errors.Errorf("name has non-ASCII characters")
-	}
-	hu := encoding.HasUpper(name)
-	if hu {
-		return errors.Errorf("name should be lowercase")
+	isAlphaNumeric := isAlphaNumeric(name)
+	if !isAlphaNumeric {
+		return errors.Errorf("name is not lowercase alphanumeric (a-z0-9)")
 	}
 
 	if len(name) > 39 {

--- a/link/github_test.go
+++ b/link/github_test.go
@@ -7,12 +7,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGithubNormalizeName(t *testing.T) {
+	name := link.Github.NormalizeName("Gabriel")
+	require.Equal(t, "gabriel", name)
+}
+
 func TestGithubValidateName(t *testing.T) {
-	err := link.Github.ValidateName("Gabriel")
-	require.EqualError(t, err, "name should be lowercase")
+	err := link.Github.ValidateName("gabriel01")
+	require.NoError(t, err)
+
+	err = link.Github.ValidateName("Gabriel")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
+
+	err = link.Github.ValidateName("Gabriel++")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
 
 	err = link.Github.ValidateName("reallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongname")
 	require.EqualError(t, err, "github name is too long, it must be less than 40 characters")
+}
+
+func TestGithubNormalizeURL(t *testing.T) {
+	testNormalizeURL(t, link.Github,
+		"gabriel",
+		"https://gist.github.com/gabriel/abcd?",
+		"https://gist.github.com/gabriel/abcd")
+
+	testNormalizeURL(t, link.Github,
+		"gabriel",
+		"https://gist.github.com/Gabriel/abcd",
+		"https://gist.github.com/gabriel/abcd")
 }
 
 func TestGithubValidateURL(t *testing.T) {

--- a/link/https.go
+++ b/link/https.go
@@ -2,7 +2,6 @@ package link
 
 import (
 	"fmt"
-	"net/url"
 	"regexp"
 	"strings"
 
@@ -15,11 +14,12 @@ type https struct{}
 // HTTPS service.
 var HTTPS = &https{}
 
-func (s *https) Name() string {
+func (s *https) ID() string {
 	return "https"
 }
 
 func (s *https) NormalizeName(name string) string {
+	name = strings.ToLower(name)
 	return name
 }
 
@@ -47,11 +47,15 @@ func (s *https) ValidateName(name string) error {
 	return nil
 }
 
-func (s *https) ValidateURL(name string, u *url.URL) (*url.URL, error) {
-	if u.String() != fmt.Sprintf("https://%s/keyspub.txt", name) {
-		return nil, errors.Errorf("invalid url: %s", u.String())
+func (s *https) NormalizeURLString(name string, urs string) (string, error) {
+	return basicURLString(strings.ToLower(urs))
+}
+
+func (s *https) ValidateURLString(name string, urs string) (string, error) {
+	if urs != fmt.Sprintf("https://%s/keyspub.txt", name) {
+		return "", errors.Errorf("invalid url: %s", urs)
 	}
-	return url.Parse(fmt.Sprintf("https://%s/keyspub.txt", name))
+	return urs, nil
 }
 
 func (s *https) CheckContent(name string, b []byte) ([]byte, error) {

--- a/link/https_test.go
+++ b/link/https_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestHTTPSNormalizeName(t *testing.T) {
+	name := link.HTTPS.NormalizeName("Keys.pub")
+	require.Equal(t, "keys.pub", name)
+}
+
 func TestHTTPSValidateName(t *testing.T) {
 	err := link.HTTPS.ValidateName("keys.pub")
 	require.NoError(t, err)

--- a/link/reddit.go
+++ b/link/reddit.go
@@ -5,32 +5,37 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/keys-pub/keys/encoding"
 	"github.com/pkg/errors"
 )
+
+// TODO Normalize spaces, check a-zA-Z0-9 instead of ASCII
 
 type reddit struct{}
 
 // Reddit service.
 var Reddit = &reddit{}
 
-func (s *reddit) Name() string {
+func (s *reddit) ID() string {
 	return "reddit"
 }
 
-func (s *reddit) NormalizeName(name string) string {
-	return name
+func (s *reddit) NormalizeURLString(name string, urs string) (string, error) {
+	return basicURLString(strings.ToLower(urs))
 }
 
-func (s *reddit) ValidateURL(name string, u *url.URL) (*url.URL, error) {
+func (s *reddit) ValidateURLString(name string, urs string) (string, error) {
+	u, err := url.Parse(urs)
+	if err != nil {
+		return "", err
+	}
 	if u.Scheme != "https" {
-		return nil, errors.Errorf("invalid scheme for url %s", u)
+		return "", errors.Errorf("invalid scheme for url %s", u)
 	}
 	switch u.Host {
 	case "reddit.com", "old.reddit.com", "www.reddit.com":
 		// OK
 	default:
-		return nil, errors.Errorf("invalid host for url %s", u)
+		return "", errors.Errorf("invalid host for url %s", u)
 	}
 	path := u.Path
 	path = strings.TrimPrefix(path, "/")
@@ -40,20 +45,25 @@ func (s *reddit) ValidateURL(name string, u *url.URL) (*url.URL, error) {
 
 	if len(paths) >= 5 && paths[0] == "r" && paths[1] == "keyspubmsgs" && paths[2] == "comments" && paths[4] == name {
 		// Request json
-		return url.Parse("https://reddit.com" + strings.TrimSuffix(u.Path, "/") + ".json")
+		ursj, err := url.Parse("https://reddit.com" + strings.TrimSuffix(u.Path, "/") + ".json")
+		if err != nil {
+			return "", err
+		}
+		return ursj.String(), nil
 	}
 
-	return nil, errors.Errorf("invalid path %s", u.Path)
+	return "", errors.Errorf("invalid path %s", u.Path)
+}
+
+func (s *reddit) NormalizeName(name string) string {
+	name = strings.ToLower(name)
+	return name
 }
 
 func (s *reddit) ValidateName(name string) error {
-	isASCII := encoding.IsASCII([]byte(name))
-	if !isASCII {
-		return errors.Errorf("name has non-ASCII characters")
-	}
-	hu := encoding.HasUpper(name)
-	if hu {
-		return errors.Errorf("name should be lowercase")
+	isAlphaNumeric := isAlphaNumeric(name)
+	if !isAlphaNumeric {
+		return errors.Errorf("name is not lowercase alphanumeric (a-z0-9)")
 	}
 	if len(name) > 20 {
 		return errors.Errorf("reddit name is too long, it must be less than 21 characters")

--- a/link/reddit_test.go
+++ b/link/reddit_test.go
@@ -7,12 +7,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRedditNormalizeName(t *testing.T) {
+	name := link.Reddit.NormalizeName("Gabriel")
+	require.Equal(t, "gabriel", name)
+}
+
 func TestRedditValidateName(t *testing.T) {
-	err := link.Github.ValidateName("Gabriel")
-	require.EqualError(t, err, "name should be lowercase")
+	err := link.Reddit.ValidateName("gabriel01")
+	require.NoError(t, err)
+
+	err = link.Reddit.ValidateName("Gabriel")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
+
+	err = link.Reddit.ValidateName("Gabriel++")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
 
 	err = link.Reddit.ValidateName("reallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongname")
 	require.EqualError(t, err, "reddit name is too long, it must be less than 21 characters")
+}
+
+func TestRedditNormalizeURL(t *testing.T) {
+	testNormalizeURL(t, link.Reddit,
+		"gabrlh",
+		"https://reddit.com/r/keyspubmsgs/comments/f8g9vd/gabrlh/?",
+		"https://reddit.com/r/keyspubmsgs/comments/f8g9vd/gabrlh/")
+
+	testNormalizeURL(t, link.Reddit,
+		"gabrlh",
+		"https://reddit.com/r/keyspubmsgs/comments/f8g9vd/Gabrlh/",
+		"https://reddit.com/r/keyspubmsgs/comments/f8g9vd/gabrlh/")
 }
 
 func TestRedditValidateURL(t *testing.T) {

--- a/link/service_test.go
+++ b/link/service_test.go
@@ -1,24 +1,25 @@
 package link_test
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/keys-pub/keys/link"
 	"github.com/stretchr/testify/require"
 )
 
+func testNormalizeURL(t *testing.T, service link.Service, name string, urs string, expected string) {
+	out, err := service.NormalizeURLString(name, urs)
+	require.NoError(t, err)
+	require.Equal(t, expected, out)
+}
+
 func testValidateURL(t *testing.T, service link.Service, name string, urs string, expected string) {
-	ur, err := url.Parse(urs)
+	urout, err := service.ValidateURLString(name, urs)
 	require.NoError(t, err)
-	urout, err := service.ValidateURL(name, ur)
-	require.NoError(t, err)
-	require.Equal(t, expected, urout.String())
+	require.Equal(t, expected, urout)
 }
 
 func testValidateURLErr(t *testing.T, service link.Service, name string, urs string, expected string) {
-	ur, err := url.Parse(urs)
-	require.NoError(t, err)
-	_, err = service.ValidateURL(name, ur)
+	_, err := service.ValidateURLString(name, urs)
 	require.EqualError(t, err, expected)
 }

--- a/link/twitter.go
+++ b/link/twitter.go
@@ -4,7 +4,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/keys-pub/keys/encoding"
 	"github.com/pkg/errors"
 )
 
@@ -13,44 +12,49 @@ type twitter struct{}
 // Twitter service.
 var Twitter = &twitter{}
 
-func (s *twitter) Name() string {
+func (s *twitter) ID() string {
 	return "twitter"
 }
 
-func (s *twitter) NormalizeName(name string) string {
-	if len(name) > 0 && name[0] == '@' {
-		return name[1:]
-	}
-	return name
+func (s *twitter) NormalizeURLString(name string, urs string) (string, error) {
+	return basicURLString(strings.ToLower(urs))
 }
 
-func (s *twitter) ValidateURL(name string, u *url.URL) (*url.URL, error) {
+func (s *twitter) ValidateURLString(name string, urs string) (string, error) {
+	u, err := url.Parse(urs)
+	if err != nil {
+		return "", err
+	}
 	if u.Scheme != "https" {
-		return nil, errors.Errorf("invalid scheme for url %s", u)
+		return "", errors.Errorf("invalid scheme for url %s", u)
 	}
 	if u.Host != "twitter.com" {
-		return nil, errors.Errorf("invalid host for url %s", u)
+		return "", errors.Errorf("invalid host for url %s", u)
 	}
 	path := u.Path
 	path = strings.TrimPrefix(path, "/")
 	paths := strings.Split(path, "/")
 	if len(paths) != 3 {
-		return nil, errors.Errorf("path invalid %s for url %s", paths, u)
+		return "", errors.Errorf("path invalid %s for url %s", paths, u)
 	}
 	if paths[0] != name {
-		return nil, errors.Errorf("path invalid (name mismatch) for url %s", u)
+		return "", errors.Errorf("path invalid (name mismatch) for url %s", u)
 	}
-	return u, nil
+	return u.String(), nil
+}
+
+func (s *twitter) NormalizeName(name string) string {
+	name = strings.ToLower(name)
+	if len(name) > 0 && name[0] == '@' {
+		name = name[1:]
+	}
+	return name
 }
 
 func (s *twitter) ValidateName(name string) error {
-	isASCII := encoding.IsASCII([]byte(name))
-	if !isASCII {
-		return errors.Errorf("name has non-ASCII characters")
-	}
-	hu := encoding.HasUpper(name)
-	if hu {
-		return errors.Errorf("name should be lowercase")
+	isAlphaNumeric := isAlphaNumeric(name)
+	if !isAlphaNumeric {
+		return errors.Errorf("name is not lowercase alphanumeric (a-z0-9)")
 	}
 
 	if len(name) > 15 {

--- a/link/twitter_test.go
+++ b/link/twitter_test.go
@@ -7,20 +7,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTwitterNormalizeName(t *testing.T) {
+	name := link.Twitter.NormalizeName("Gabriel")
+	require.Equal(t, "gabriel", name)
+}
+
 func TestTwitterValidateName(t *testing.T) {
-	err := link.Twitter.ValidateName("Gabriel")
-	require.EqualError(t, err, "name should be lowercase")
+	err := link.Twitter.ValidateName("gabriel01")
+	require.NoError(t, err)
+
+	err = link.Twitter.ValidateName("Gabriel")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
+
+	err = link.Twitter.ValidateName("Gabriel++")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
 
 	err = link.Twitter.ValidateName("reallylongnamereallylongnamereallylongnamereallylongnamereallylongnamereallylongname")
 	require.EqualError(t, err, "twitter name is too long, it must be less than 16 characters")
 }
 
-func TestTwitterValidateURL(t *testing.T) {
-	testValidateURL(t, link.Twitter,
+func TestTwitterNormalizeURL(t *testing.T) {
+	testNormalizeURL(t, link.Reddit,
 		"boboloblaw",
-		"https://twitter.com/boboloblaw/status/1250914920146669568",
+		"https://twitter.com/Boboloblaw/status/1250914920146669568?",
 		"https://twitter.com/boboloblaw/status/1250914920146669568")
 
+	testNormalizeURL(t, link.Reddit,
+		"boboloblaw",
+		"https://twitter.com/Boboloblaw/status/1250914920146669568?",
+		"https://twitter.com/boboloblaw/status/1250914920146669568")
+}
+
+func TestTwitterValidateURL(t *testing.T) {
 	testValidateURLErr(t, link.Twitter,
 		"boboloblaw",
 		"https://twitter.com/bobolobla/status/1250914920146669568",

--- a/user/search_test.go
+++ b/user/search_test.go
@@ -185,11 +185,11 @@ func TestUserValidateName(t *testing.T) {
 
 	// Test MixedCase
 	_, err := saveUser(ust, scs, key, "MixedCase", "github", clock, req)
-	require.EqualError(t, err, "name should be lowercase")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
 	_, err = saveUser(ust, scs, key, "MixedCase", "twitter", clock, req)
-	require.EqualError(t, err, "name should be lowercase")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
 	_, err = saveUser(ust, scs, key, "MixedCase", "reddit", clock, req)
-	require.EqualError(t, err, "name should be lowercase")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
 
 	// Long length
 	_, err = saveUser(ust, scs, key, "reallylongusernamereallylongusernamereallylongusername", "github", clock, req)
@@ -228,7 +228,7 @@ func TestUserValidateUpdateInvalid(t *testing.T) {
 	sc := keys.NewSigchain(key.ID())
 
 	_, err = user.NewUserSigchainStatement(sc, usr, key, clock.Now())
-	require.EqualError(t, err, "name should be lowercase")
+	require.EqualError(t, err, "name is not lowercase alphanumeric (a-z0-9)")
 
 	// Go around validate check and add
 	b, err := usr.MarshalJSON()

--- a/user/store_test.go
+++ b/user/store_test.go
@@ -400,17 +400,12 @@ func TestNewUser(t *testing.T) {
 	require.EqualError(t, uerr, "name is empty")
 	require.Nil(t, u8)
 
-	u9, uerr := user.NewUser(ust, sk.ID(), "twitter", "@gbrltest", "https://twitter.com/gbrltest/status/1234", 1)
-	require.NoError(t, uerr)
-	require.NotNil(t, u9)
-	require.Equal(t, "gbrltest", u9.Name)
-
-	u10, uerr0 := user.NewUser(ust, sk.ID(), "twitter", "Gbrltest", "https://twitter.com/gbrltest/status/1234", 1)
-	require.EqualError(t, uerr0, "name should be lowercase")
+	u10, uerr := user.NewUser(ust, sk.ID(), "twitter", "Gbrltest", "https://twitter.com/gbrltest/status/1234", 1)
+	require.EqualError(t, uerr, "name is not lowercase alphanumeric (a-z0-9)")
 	require.Nil(t, u10)
 
-	u11, uerr1 := user.NewUser(ust, sk.ID(), "twitter", "gbrltest🤓", "https://twitter.com/gbrltest/status/1234", 1)
-	require.EqualError(t, uerr1, "name has non-ASCII characters")
+	u11, uerr := user.NewUser(ust, sk.ID(), "twitter", "gbrltest🤓", "https://twitter.com/gbrltest/status/1234", 1)
+	require.EqualError(t, uerr, "name is not lowercase alphanumeric (a-z0-9)")
 	require.Nil(t, u11)
 
 	u12, uerr := user.NewUser(ust, sk.ID(), "twitter", "gbrltest", "twitter.com/gbrltest/status/1234", 1)

--- a/util/request.go
+++ b/util/request.go
@@ -115,7 +115,7 @@ func (e ErrTemporary) Temporary() bool {
 
 // Requestor defines how to get bytes from a URL.
 type Requestor interface {
-	RequestURL(ctx context.Context, u *url.URL) ([]byte, error)
+	RequestURLString(ctx context.Context, urs string) ([]byte, error)
 }
 
 type requestor struct{}
@@ -125,10 +125,9 @@ func NewHTTPRequestor() Requestor {
 	return requestor{}
 }
 
-// RequestURL requests a URL.
-func (r requestor) RequestURL(ctx context.Context, u *url.URL) ([]byte, error) {
-	logger.Infof("Requesting URL %s", u)
-	_, body, err := doRequest(client(), "GET", u.String(), nil)
+// RequestURLString requests an URL string.
+func (r requestor) RequestURLString(ctx context.Context, urs string) ([]byte, error) {
+	_, body, err := doRequest(client(), "GET", urs, nil)
 	if err != nil {
 		logger.Warningf("Failed request: %s", err)
 	}
@@ -171,7 +170,7 @@ func (r *MockRequestor) SetError(url string, err error) {
 	r.resp[url] = &mockResponse{err: err}
 }
 
-// RequestURL ...
-func (r *MockRequestor) RequestURL(ctx context.Context, u *url.URL) ([]byte, error) {
-	return r.Response(u.String())
+// RequestURLString ...
+func (r *MockRequestor) RequestURLString(ctx context.Context, urs string) ([]byte, error) {
+	return r.Response(urs)
 }

--- a/util/request_test.go
+++ b/util/request_test.go
@@ -2,7 +2,6 @@ package util_test
 
 import (
 	"context"
-	"net/url"
 	"testing"
 
 	"github.com/keys-pub/keys/util"
@@ -13,9 +12,7 @@ func TestReddit(t *testing.T) {
 	t.Skip()
 	req := util.NewHTTPRequestor()
 
-	ur, err := url.Parse("https://reddit.com/r/keyspubmsgs/comments/f8g9vd/gabrlh.json")
-	require.NoError(t, err)
-
-	_, err = req.RequestURL(context.TODO(), ur)
+	urs := "https://reddit.com/r/keyspubmsgs/comments/f8g9vd/gabrlh.json"
+	_, err := req.RequestURLString(context.TODO(), urs)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
@TheLastProject highlighted some issues with mixed case usernames here: https://github.com/keys-pub/keys/pull/23
This PR expands upon that.

- ValidateURL becomes ValidateURLString.
- URLs are always strings, except when validating.
- NormalizeURLString normalizes URL strings.
- User names check against regex [a-z0-9] instead of just ASCII
- We rename Service.Name() to Service.ID()
- user.NewUser doesn't normalize input. NewUserForSigning still does.
- Tests and test fixes from @TheLastProject
- Requestor.RequestURL renamed to RequestURLString
