### PR TITLE
keyring: Provision (refactor)

### DIFF
--- a/keyring/auth.go
+++ b/keyring/auth.go
@@ -27,6 +27,14 @@ func KeyForPassword(password string, salt []byte) (SecretKey, error) {
 	return bytes32(akey), nil
 }
 
+// Salt is default salt value, generated on first access and persisted
+// until Reset().
+// This salt value is not encrypted in the keyring.
+// Doesn't require Unlock().
+func (k *Keyring) Salt() ([]byte, error) {
+	return salt(k.st, k.service)
+}
+
 // salt returns a salt value, generating it on first access if it doesn't exist.
 func salt(st Store, service string) ([]byte, error) {
 	salt, err := st.Get(service, reserved("salt"))

--- a/keyring/auth.go
+++ b/keyring/auth.go
@@ -14,29 +14,8 @@ var ErrLocked = errors.New("keyring is locked")
 // ErrAlreadySetup if already setup.
 var ErrAlreadySetup = errors.New("keyring is already setup")
 
-// Auth ...
-type Auth interface {
-	// ID is an identifier for auth.
-	ID() string
-	// Key for auth.
-	Key() SecretKey
-}
-
-type auth struct {
-	id  string
-	key SecretKey
-}
-
-func (k auth) Key() SecretKey {
-	return k.key
-}
-
-func (k auth) ID() string {
-	return k.id
-}
-
-// NewPasswordAuth generates a key from a password and salt.
-func NewPasswordAuth(password string, salt []byte) (Auth, error) {
+// KeyForPassword generates a key from a password and salt.
+func KeyForPassword(password string, salt []byte) (SecretKey, error) {
 	if len(salt) < 16 {
 		return nil, errors.Errorf("not enough salt")
 	}
@@ -45,18 +24,7 @@ func NewPasswordAuth(password string, salt []byte) (Auth, error) {
 	}
 
 	akey := argon2.IDKey([]byte(password), salt[:], 1, 64*1024, 4, 32)
-	return &auth{
-		id:  newAuthID(),
-		key: bytes32(akey),
-	}, nil
-}
-
-// NewAuth returns auth for key and type.
-func NewAuth(id string, key SecretKey) Auth {
-	return &auth{
-		id:  id,
-		key: key,
-	}
+	return bytes32(akey), nil
 }
 
 // salt returns a salt value, generating it on first access if it doesn't exist.

--- a/keyring/copy_test.go
+++ b/keyring/copy_test.go
@@ -1,10 +1,12 @@
 package keyring_test
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
 	"github.com/keys-pub/keys"
+	"github.com/keys-pub/keys/encoding"
 	"github.com/keys-pub/keys/keyring"
 	"github.com/stretchr/testify/require"
 )
@@ -14,8 +16,12 @@ func TestCopy(t *testing.T) {
 
 	// Keyring #1 (mem)
 	kr := keyring.NewMem(false)
-	auth := keyring.NewAuth("test", keys.Rand32())
-	_, err = kr.Setup(auth)
+	key := keys.Rand32()
+	id := encoding.MustEncode(bytes.Repeat([]byte{0x01}, 32), encoding.Base62)
+	provision := &keyring.Provision{
+		ID: id,
+	}
+	err = kr.Setup(key, provision)
 	require.NoError(t, err)
 
 	item := keyring.NewItem(keys.Rand3262(), []byte("testpassword"), "", time.Now())
@@ -28,10 +34,10 @@ func TestCopy(t *testing.T) {
 	// Copy
 	ids, err := keyring.Copy(kr, kr2)
 	require.NoError(t, err)
-	require.Equal(t, []string{"#auth-test", item.ID}, ids)
+	require.Equal(t, []string{"#auth-0El6XFXwsUFD8J2vGxsaboW7rZYnQRBP5d9erwRwd29", "#provision-0El6XFXwsUFD8J2vGxsaboW7rZYnQRBP5d9erwRwd29", item.ID}, ids)
 
 	// Unlock #2
-	_, err = kr2.Unlock(auth)
+	_, err = kr2.Unlock(key)
 	require.NoError(t, err)
 
 	out, err := kr2.Get(item.ID)

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -197,7 +197,7 @@ func (k *Keyring) Exists(id string) (bool, error) {
 }
 
 // Unlock with auth.
-// Returns provision identifier used to unlock.
+// Returns provision used to unlock.
 func (k *Keyring) Unlock(key SecretKey) (*Provision, error) {
 	id, masterKey, err := authUnlock(k.st, k.service, key)
 	if err != nil {
@@ -230,14 +230,6 @@ func (k *Keyring) MasterKey() SecretKey {
 func (k *Keyring) Lock() error {
 	k.masterKey = nil
 	return nil
-}
-
-// Salt is default salt value, generated on first access and persisted
-// until Reset().
-// This salt value is not encrypted in the keyring.
-// Doesn't require Unlock().
-func (k *Keyring) Salt() ([]byte, error) {
-	return salt(k.st, k.service)
 }
 
 // Reset keyring.

--- a/keyring/mem.go
+++ b/keyring/mem.go
@@ -1,9 +1,11 @@
 package keyring
 
 import (
+	"bytes"
 	"sort"
 	"strings"
 
+	"github.com/keys-pub/keys/encoding"
 	"github.com/pkg/errors"
 )
 
@@ -13,8 +15,11 @@ import (
 func NewMem(setup bool) *Keyring {
 	kr := newKeyring("", Mem())
 	if setup {
-		_, err := kr.Setup(NewAuth("mem", rand32()))
-		if err != nil {
+		id := encoding.MustEncode(bytes.Repeat([]byte{0xFF}, 32), encoding.Base62)
+		provision := &Provision{
+			ID: id,
+		}
+		if err := kr.Setup(rand32(), provision); err != nil {
 			panic(err)
 		}
 	}

--- a/keyring/provision.go
+++ b/keyring/provision.go
@@ -280,34 +280,6 @@ func NewProvision(typ AuthType) *Provision {
 	}
 }
 
-// loadProvisions loads all provision.
-func (k *Keyring) loadProvisions() ([]*Provision, error) {
-	st := k.Store()
-	service := k.Service()
-	ids, err := st.IDs(service, WithReservedPrefix(provisionPrefix))
-	if err != nil {
-		return nil, err
-	}
-	logger.Debugf("Looking up provisions %v", ids)
-	provisions := make([]*Provision, 0, len(ids))
-	for _, id := range ids {
-		b, err := st.Get(service, id)
-		if err != nil {
-			return nil, err
-		}
-		if b == nil {
-			logger.Errorf("Missing provision for %s", id)
-			continue
-		}
-		var provision Provision
-		if err := msgpack.Unmarshal(b, &provision); err != nil {
-			return nil, err
-		}
-		provisions = append(provisions, &provision)
-	}
-	return provisions, nil
-}
-
 // loadProvision loads provision for id.
 func (k *Keyring) loadProvision(id string) (*Provision, error) {
 	st := k.Store()

--- a/keyring/provision.go
+++ b/keyring/provision.go
@@ -1,40 +1,150 @@
 package keyring
 
 import (
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/keys-pub/keys/encoding"
 	"github.com/pkg/errors"
+	"github.com/vmihailenco/msgpack/v4"
 )
 
-func authSetup(st Store, service string, auth Auth) (string, SecretKey, error) {
-	// MK is the master key.
-	mk := rand32()
-	id, err := authProvision(st, service, auth, mk)
+// Setup auth, if no auth exists.
+// Returns ErrAlreadySetup if already setup.
+// Doesn't require Unlock().
+func (k *Keyring) Setup(key SecretKey, provision *Provision) error {
+	status, err := k.Status()
 	if err != nil {
-		return "", nil, err
+		return err
 	}
-	return id, mk, nil
+	if status != Setup {
+		return ErrAlreadySetup
+	}
+	if provision == nil {
+		return errors.Errorf("no provision")
+	}
+	mk, err := authSetup(k.st, k.service, provision.ID, key)
+	if err != nil {
+		return err
+	}
+
+	if provision != nil {
+		if err := k.saveProvision(provision); err != nil {
+			return err
+		}
+	}
+
+	k.masterKey = mk
+	return nil
 }
 
-func authProvision(st Store, service string, auth Auth, mk SecretKey) (string, error) {
-	if mk == nil {
-		return "", ErrLocked
+// Provision new auth.
+// Requires Unlock().
+func (k *Keyring) Provision(key SecretKey, provision *Provision) error {
+	if k.masterKey == nil {
+		return ErrLocked
+	}
+	if provision == nil {
+		return errors.Errorf("no provision")
 	}
 
-	id := auth.ID()
+	if err := authProvision(k.st, k.service, provision.ID, key, k.masterKey); err != nil {
+		return err
+	}
+
+	if provision != nil {
+		if err := k.saveProvision(provision); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Provisions are currently provisioned auth.
+// Doesn't require Unlock().
+func (k *Keyring) Provisions() ([]*Provision, error) {
+	ids, err := provisionIDs(k.st, k.service)
+	if err != nil {
+		return nil, err
+	}
+	provisions := make([]*Provision, 0, len(ids))
+	for _, id := range ids {
+		provision, err := k.loadProvision(id)
+		if err != nil {
+			return nil, err
+		}
+		if provision == nil {
+			provision = &Provision{
+				ID: id,
+			}
+		}
+		provisions = append(provisions, provision)
+	}
+
+	// Check for v1 auth
+	v1, err := k.Store().Exists(k.service, "#auth")
+	if err != nil {
+		return nil, err
+	}
+	if v1 {
+		provisions = append(provisions, &Provision{ID: authV1ID})
+	}
+
+	// Sort by time
+	sort.Slice(provisions, func(i, j int) bool { return provisions[i].CreatedAt.Before(provisions[j].CreatedAt) })
+
+	return provisions, nil
+}
+
+// Deprovision auth.
+// Doesn't require Unlock().
+func (k *Keyring) Deprovision(id string) (bool, error) {
+	ok, err := authDeprovision(k.st, k.service, id)
+	if err != nil {
+		return false, err
+	}
+	_, err = k.deleteProvision(id)
+	return ok, err
+}
+
+// SaveProvision for auth methods that need to store registration data before
+// key is available (for example, FIDO2 hmac-secret).
+func (k *Keyring) SaveProvision(provision *Provision) error {
+	return k.saveProvision(provision)
+}
+
+func authSetup(st Store, service string, id string, key SecretKey) (SecretKey, error) {
+	// MK is the master key.
+	mk := rand32()
+	if err := authProvision(st, service, id, key, mk); err != nil {
+		return nil, err
+	}
+	return mk, nil
+}
+
+func authProvision(st Store, service string, id string, key SecretKey, mk SecretKey) error {
+	if mk == nil {
+		return ErrLocked
+	}
+	if id == "" {
+		return errors.Errorf("no provision id")
+	}
 	krid := reserved("auth-") + id
 
 	logger.Debugf("Provisioning %s", id)
 	item := NewItem(krid, mk[:], "", time.Now())
-	if err := setItem(st, service, item, auth.Key()); err != nil {
-		return "", err
+	if err := setItem(st, service, item, key); err != nil {
+		return err
 	}
-	return id, nil
+	return nil
 }
 
 func authDeprovision(st Store, service string, id string) (bool, error) {
+	if id == "" {
+		return false, errors.Errorf("no provision id")
+	}
 	logger.Debugf("Deprovisioning %s", id)
 	krid := reserved("auth-") + id
 	ok, err := st.Delete(service, krid)
@@ -45,7 +155,7 @@ func authDeprovision(st Store, service string, id string) (bool, error) {
 }
 
 func authIDs(st Store, service string) ([]string, error) {
-	krids, err := st.IDs(service, WithReservedPrefix("auth"))
+	krids, err := st.IDs(service, WithReservedPrefix("#auth"))
 	if err != nil {
 		return nil, err
 	}
@@ -60,13 +170,25 @@ func authIDs(st Store, service string) ([]string, error) {
 	return ids, nil
 }
 
-// authUnlock returns (identifier, master key) or ("", nil) if a matching auth
-// is not found.
-func authUnlock(st Store, service string, auth Auth) (string, SecretKey, error) {
-	if auth == nil {
-		return "", nil, errors.Errorf("no auth specified")
+func provisionIDs(st Store, service string) ([]string, error) {
+	krids, err := st.IDs(service, WithReservedPrefix(provisionPrefix))
+	if err != nil {
+		return nil, err
 	}
+	ids := make([]string, 0, len(krids))
+	for _, krid := range krids {
+		id := parseProvisionID(krid)
+		if id == "" {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
 
+// authUnlock returns (id, master key) or ("", nil) if a matching auth
+// is not found.
+func authUnlock(st Store, service string, key SecretKey) (string, SecretKey, error) {
 	ids, err := authIDs(st, service)
 	if err != nil {
 		return "", nil, err
@@ -80,7 +202,7 @@ func authUnlock(st Store, service string, auth Auth) (string, SecretKey, error) 
 			krid = reserved("auth-") + id
 		}
 
-		item, err := getItem(st, service, krid, auth.Key())
+		item, err := getItem(st, service, krid, key)
 		if err != nil {
 			continue
 		}
@@ -98,7 +220,7 @@ func authUnlock(st Store, service string, auth Auth) (string, SecretKey, error) 
 	return "", nil, nil
 }
 
-func newAuthID() string {
+func newProvisionID() string {
 	b := rand32()
 	return encoding.MustEncode(b[:], encoding.Base62)
 }
@@ -113,4 +235,120 @@ func parseAuthID(s string) string {
 	return s[6:]
 }
 
+func parseProvisionID(s string) string {
+	if !strings.HasPrefix(s, "#provision-") {
+		return ""
+	}
+	return s[11:]
+}
+
 const authV1ID = "v1.auth"
+
+// AuthType describes an auth method.
+type AuthType string
+
+const (
+	// UnknownAuth ...
+	UnknownAuth AuthType = ""
+	// PasswordAuth ...
+	PasswordAuth AuthType = "password"
+	// FIDO2HMACSecretAuth ...
+	FIDO2HMACSecretAuth AuthType = "fido2-hmac-secret" // #nosec
+)
+
+var provisionPrefix = reserved("provision-")
+
+// Provision is unencrypted provision and parameters used by client auth.
+type Provision struct {
+	ID        string    `msgpack:"id"`
+	Type      AuthType  `msgpack:"type"`
+	CreatedAt time.Time `msgpack:"cts"`
+
+	// For FIDO2HMACSecret
+
+	AAGUID string `msgpack:"aaguid"`
+	Salt   []byte `msgpack:"salt"`
+	NoPin  bool   `msgpack:"nopin"`
+}
+
+// NewProvision creates a new provision.
+func NewProvision(typ AuthType) *Provision {
+	return &Provision{
+		ID:        newProvisionID(),
+		Type:      typ,
+		CreatedAt: time.Now(),
+	}
+}
+
+// loadProvisions loads all provision.
+func (k *Keyring) loadProvisions() ([]*Provision, error) {
+	st := k.Store()
+	service := k.Service()
+	ids, err := st.IDs(service, WithReservedPrefix(provisionPrefix))
+	if err != nil {
+		return nil, err
+	}
+	logger.Debugf("Looking up provisions %v", ids)
+	provisions := make([]*Provision, 0, len(ids))
+	for _, id := range ids {
+		b, err := st.Get(service, id)
+		if err != nil {
+			return nil, err
+		}
+		if b == nil {
+			logger.Errorf("Missing provision for %s", id)
+			continue
+		}
+		var provision Provision
+		if err := msgpack.Unmarshal(b, &provision); err != nil {
+			return nil, err
+		}
+		provisions = append(provisions, &provision)
+	}
+	return provisions, nil
+}
+
+// loadProvision loads provision for id.
+func (k *Keyring) loadProvision(id string) (*Provision, error) {
+	st := k.Store()
+	service := k.Service()
+	logger.Debugf("Loading provision %s", id)
+
+	b, err := st.Get(service, provisionPrefix+id)
+	if err != nil {
+		return nil, err
+	}
+	if b == nil {
+		return nil, nil
+	}
+	var provision Provision
+	if err := msgpack.Unmarshal(b, &provision); err != nil {
+		return nil, err
+	}
+	return &provision, nil
+}
+
+// saveProvision saves provision.
+func (k *Keyring) saveProvision(provision *Provision) error {
+	logger.Debugf("Saving provision %s", provision.ID)
+	st := k.Store()
+	service := k.Service()
+	krid := provisionPrefix + provision.ID
+	b, err := msgpack.Marshal(provision)
+	if err != nil {
+		return err
+	}
+	if err := st.Set(service, krid, b); err != nil {
+		return err
+	}
+	return nil
+}
+
+// deleteProvision removes provision.
+func (k *Keyring) deleteProvision(id string) (bool, error) {
+	logger.Debugf("Deleting provision %s", id)
+	st := k.Store()
+	service := k.Service()
+	krid := provisionPrefix + id
+	return st.Delete(service, krid)
+}

--- a/keyring/provision_test.go
+++ b/keyring/provision_test.go
@@ -1,0 +1,98 @@
+package keyring_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/keys-pub/keys"
+	"github.com/keys-pub/keys/encoding"
+	"github.com/keys-pub/keys/keyring"
+	"github.com/keys-pub/keys/tsutil"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v4"
+)
+
+func TestProvision(t *testing.T) {
+	var err error
+
+	kr := keyring.NewMem(true)
+	key := keys.Rand32()
+	id := encoding.MustEncode(bytes.Repeat([]byte{0x01}, 32), encoding.Base62)
+	provision := &keyring.Provision{
+		ID: id,
+	}
+	err = kr.Provision(key, provision)
+	require.NoError(t, err)
+
+	provisions, err := kr.Provisions()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(provisions))
+	require.Equal(t, "0El6XFXwsUFD8J2vGxsaboW7rZYnQRBP5d9erwRwd29", provisions[0].ID)
+	require.Equal(t, "yhjskwdA6OZ1AL1YmHWZWm8LLG7HjnuCA2j5rOw8Xp1", provisions[1].ID)
+}
+
+func TestSaveProvision(t *testing.T) {
+	var err error
+
+	kr := keyring.NewMem(false)
+	id := encoding.MustEncode(bytes.Repeat([]byte{0x01}, 32), encoding.Base62)
+	provision := &keyring.Provision{
+		ID: id,
+	}
+	err = kr.SaveProvision(provision)
+	require.NoError(t, err)
+
+	provisions, err := kr.Provisions()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(provisions))
+	require.Equal(t, "0El6XFXwsUFD8J2vGxsaboW7rZYnQRBP5d9erwRwd29", provisions[0].ID)
+}
+
+func TestProvisionMarshal(t *testing.T) {
+	var err error
+
+	clock := tsutil.NewClock()
+	id := encoding.MustEncode(bytes.Repeat([]byte{0x01}, 32), encoding.Base62)
+	salt := bytes.Repeat([]byte{0x02}, 32)
+	provision := &keyring.Provision{
+		ID:        id,
+		Type:      keyring.PasswordAuth,
+		AAGUID:    "123",
+		Salt:      salt,
+		NoPin:     true,
+		CreatedAt: clock.Now(),
+	}
+	kr := keyring.NewMem(true)
+	key := keys.Rand32()
+	err = kr.Provision(key, provision)
+	require.NoError(t, err)
+
+	provisions, err := kr.Provisions()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(provisions))
+	require.Equal(t, "yhjskwdA6OZ1AL1YmHWZWm8LLG7HjnuCA2j5rOw8Xp1", provisions[0].ID)
+	out := provisions[1]
+	require.Equal(t, provision.ID, out.ID)
+	require.Equal(t, provision.Salt, out.Salt)
+	require.Equal(t, provision.AAGUID, out.AAGUID)
+	require.Equal(t, provision.NoPin, out.NoPin)
+	require.Equal(t, provision.Type, out.Type)
+	require.Equal(t, provision.CreatedAt.UTC(), out.CreatedAt.UTC())
+
+	b, err := msgpack.Marshal(provision)
+	require.NoError(t, err)
+	expected := `([]uint8) (len=134 cap=267) {
+ 00000000  86 a2 69 64 d9 2b 30 45  6c 36 58 46 58 77 73 55  |..id.+0El6XFXwsU|
+ 00000010  46 44 38 4a 32 76 47 78  73 61 62 6f 57 37 72 5a  |FD8J2vGxsaboW7rZ|
+ 00000020  59 6e 51 52 42 50 35 64  39 65 72 77 52 77 64 32  |YnQRBP5d9erwRwd2|
+ 00000030  39 a4 74 79 70 65 a8 70  61 73 73 77 6f 72 64 a3  |9.type.password.|
+ 00000040  63 74 73 d7 ff 00 3d 09  00 49 96 02 d2 a6 61 61  |cts...=..I....aa|
+ 00000050  67 75 69 64 a3 31 32 33  a4 73 61 6c 74 c4 20 02  |guid.123.salt. .|
+ 00000060  02 02 02 02 02 02 02 02  02 02 02 02 02 02 02 02  |................|
+ 00000070  02 02 02 02 02 02 02 02  02 02 02 02 02 02 02 a5  |................|
+ 00000080  6e 6f 70 69 6e c3                                 |nopin.|
+}
+`
+	require.Equal(t, expected, spew.Sdump(b))
+}

--- a/store.go
+++ b/store.go
@@ -27,11 +27,6 @@ func NewMemStore(setup bool) *Store {
 	return NewStore(mem)
 }
 
-// Keyring used by Store.
-func (k *Store) Keyring() *keyring.Keyring {
-	return k.kr
-}
-
 // EdX25519Key returns an EdX25519Key from the keyring.
 func (k *Store) EdX25519Key(kid ID) (*EdX25519Key, error) {
 	logger.Infof("Store load sign key for %s", kid)


### PR DESCRIPTION
```go
// Provision is unencrypted provision and parameters used by client auth.
type Provision struct {
	ID        string    `msgpack:"id"`
	Type      AuthType  `msgpack:"type"`
	CreatedAt time.Time `msgpack:"cts"`

	// For FIDO2HMACSecret

	AAGUID string `msgpack:"aaguid"`
	Salt   []byte `msgpack:"salt"`
	NoPin  bool   `msgpack:"nopin"`
}
```