### PR TITLE
Support SAN for Go 1.15+

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -89,6 +89,7 @@ func GenerateCertificateKey(commonName string, isCA bool, parent *x509.Certifica
 		NotAfter:    notAfter,
 		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    []string{commonName},
 	}
 
 	if isCA {


### PR DESCRIPTION
Starting from Go 1.15+ Certificate without subjectAltName will fail with error: "x509: certificate relies on legacy Common Name field"

More info: https://github.com/golang/go/issues/39568
This is only for Domain names and does not support IPAddresses: https://godoc.org/crypto/x509#Certificate

I did not use scripts/test to test if this will affect other parts of the code.